### PR TITLE
Admin setup

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -111,9 +111,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/4.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'FR-fr'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Paris'
 
 USE_I18N = True
 

--- a/profiles/admin.py
+++ b/profiles/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import Legal, Natural
 
-# Register your models here.
+admin.site.register([Legal, Natural])


### PR DESCRIPTION
[Trollo](https://trello.com/c/oWpJcAhf/14-back-office)
Tout simplement ajouté les modèles de profil dans le BO. Il faut créer un superuser en local pour y accèder.

Question, est-ce que tu sais à quoi servent les `ModelAdmin` ? Je suppose que  c'est des modèles qui ne serviront que dans le BO, mais j'ai du mal à imaginer un use-case
Example dans la doc : https://devdocs.io/django~4.1/ref/contrib/admin/index#django.contrib.admin.register
Pour l'instant, je n'ai vu que ce cas d'utilisation, que je vais appliquer dans le ticket suivant : https://docs.djangoproject.com/en/4.1/topics/auth/customizing/#extending-the-existing-user-model